### PR TITLE
Implement a readonly character group list for user profiles

### DIFF
--- a/@types/schema.d.ts
+++ b/@types/schema.d.ts
@@ -1886,7 +1886,7 @@ export type GetUserProfileQueryVariables = Exact<{
 }>;
 
 
-export type GetUserProfileQuery = { __typename?: 'Query', getUser?: { __typename?: 'User', id: string, name?: string | null, username?: string | null, created_at?: number | null, profile?: string | null, profile_html?: string | null, profile_image_url?: string | null, blocks?: boolean | null, is_blocked?: boolean | null, is_followed?: boolean | null, is_admin?: boolean | null, is_managed?: boolean | null, is_moderator?: boolean | null, is_supporter?: boolean | null, is_patron?: boolean | null, character_groups?: Array<{ __typename?: 'CharacterGroup', name: string, characters_count: number } | null> | null } | null };
+export type GetUserProfileQuery = { __typename?: 'Query', getUser?: { __typename?: 'User', id: string, name?: string | null, username?: string | null, created_at?: number | null, profile?: string | null, profile_html?: string | null, profile_image_url?: string | null, blocks?: boolean | null, is_blocked?: boolean | null, is_followed?: boolean | null, is_admin?: boolean | null, is_managed?: boolean | null, is_moderator?: boolean | null, is_supporter?: boolean | null, is_patron?: boolean | null, character_groups?: Array<{ __typename?: 'CharacterGroup', id?: string | null, name: string, characters_count: number } | null> | null } | null };
 
 export type GetCharacterImagesQueryVariables = Exact<{
   username: Scalars['String'];
@@ -5000,6 +5000,7 @@ export const GetUserProfileDocument = gql`
     is_supporter
     is_patron
     character_groups {
+      id
       name
       characters_count
     }

--- a/@types/schema.d.ts
+++ b/@types/schema.d.ts
@@ -1886,7 +1886,7 @@ export type GetUserProfileQueryVariables = Exact<{
 }>;
 
 
-export type GetUserProfileQuery = { __typename?: 'Query', getUser?: { __typename?: 'User', id: string, name?: string | null, username?: string | null, created_at?: number | null, profile?: string | null, profile_html?: string | null, profile_image_url?: string | null, blocks?: boolean | null, is_blocked?: boolean | null, is_followed?: boolean | null, is_admin?: boolean | null, is_managed?: boolean | null, is_moderator?: boolean | null, is_supporter?: boolean | null, is_patron?: boolean | null, character_groups?: Array<{ __typename?: 'CharacterGroup', id?: string | null, name: string, characters_count: number } | null> | null } | null };
+export type GetUserProfileQuery = { __typename?: 'Query', getUser?: { __typename?: 'User', id: string, name?: string | null, username?: string | null, created_at?: number | null, characters_count?: string | null, profile?: string | null, profile_html?: string | null, profile_image_url?: string | null, blocks?: boolean | null, is_blocked?: boolean | null, is_followed?: boolean | null, is_admin?: boolean | null, is_managed?: boolean | null, is_moderator?: boolean | null, is_supporter?: boolean | null, is_patron?: boolean | null, character_groups?: Array<{ __typename?: 'CharacterGroup', id?: string | null, name: string, characters_count: number } | null> | null } | null };
 
 export type GetCharacterImagesQueryVariables = Exact<{
   username: Scalars['String'];
@@ -4988,6 +4988,7 @@ export const GetUserProfileDocument = gql`
     name
     username
     created_at
+    characters_count
     profile
     profile_html
     profile_image_url

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -4,13 +4,15 @@ import getUserProfile from '../../src/graph/queries/getUserProfile.graphql';
 import UserView from 'components/User/View';
 import {GetUserProfileQuery} from "../../@types/schema";
 import type { GsspParams, GsspResult } from '@refsheet/types';
+import type { CharacterGroup } from "@refsheet/components/User/types";
 
 export interface UserProfileProps {
+    characterGroups: readonly CharacterGroup[]; 
     user: NonNullable<GetUserProfileQuery['getUser']>;
 }
 
-const UserProfile: React.FC<UserProfileProps> = ({user}) => {
-    return <UserView user={user}/>;
+const UserProfile: React.FC<UserProfileProps> = ({ characterGroups, user}) => {
+    return <UserView characterGroups={characterGroups} user={user}/>;
 }
 
 export async function getServerSideProps({params}: GsspParams<{ username: string }>): GsspResult<UserProfileProps> {
@@ -27,6 +29,17 @@ export async function getServerSideProps({params}: GsspParams<{ username: string
 
     return {
         props: {
+            characterGroups: data.getUser.character_groups?.map((group): CharacterGroup | null => {
+                if (!group || !group.id) {
+                    return null;
+                }
+
+                return {
+                    id: group.id,
+                    characterCount: group.characters_count,
+                    name: group.name,
+                }
+            }).filter((x): x is CharacterGroup => !!x) ?? [],
             user: data.getUser
         }
     }

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -7,12 +7,13 @@ import type { GsspParams, GsspResult } from '@refsheet/types';
 import type { CharacterGroup } from "@refsheet/components/User/types";
 
 export interface UserProfileProps {
-    characterGroups: readonly CharacterGroup[]; 
+    characterGroups: readonly CharacterGroup[];
+    numCharacters: number;
     user: NonNullable<GetUserProfileQuery['getUser']>;
 }
 
-const UserProfile: React.FC<UserProfileProps> = ({ characterGroups, user}) => {
-    return <UserView characterGroups={characterGroups} user={user}/>;
+const UserProfile: React.FC<UserProfileProps> = ({ characterGroups, numCharacters, user}) => {
+    return <UserView characterGroups={characterGroups} numCharacters={numCharacters} user={user}/>;
 }
 
 export async function getServerSideProps({params}: GsspParams<{ username: string }>): GsspResult<UserProfileProps> {
@@ -40,6 +41,7 @@ export async function getServerSideProps({params}: GsspParams<{ username: string
                     name: group.name,
                 }
             }).filter((x): x is CharacterGroup => !!x) ?? [],
+            numCharacters: parseInt(data.getUser.characters_count ?? "0", 10),
             user: data.getUser
         }
     }

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -1,34 +1,33 @@
 import React from 'react'
-import {GetServerSideProps} from "next";
-import {ParsedUrlQuery} from "querystring";
 import client from "services/ApplicationService";
 import getUserProfile from '../../src/graph/queries/getUserProfile.graphql';
-import NotFound from "components/Shared/views/NotFound";
 import UserView from 'components/User/View';
 import {GetUserProfileQuery} from "../../@types/schema";
-
-export interface UserProfileParams extends ParsedUrlQuery {
-    username: string;
-}
+import type { GsspParams, GsspResult } from '@refsheet/types';
 
 export interface UserProfileProps {
-    user: GetUserProfileQuery['getUser'];
+    user: NonNullable<GetUserProfileQuery['getUser']>;
 }
 
 const UserProfile: React.FC<UserProfileProps> = ({user}) => {
-    if (!user) return <NotFound/>;
     return <UserView user={user}/>;
 }
 
-export const getServerSideProps: GetServerSideProps<UserProfileProps, UserProfileParams> = async ({params}) => {
+export async function getServerSideProps({params}: GsspParams<{ username: string }>): GsspResult<UserProfileProps> {
     const {data} = await client.query<GetUserProfileQuery>({
         query: getUserProfile,
         variables: {username: params?.username}
     });
 
+    if (!data.getUser) {
+        return {
+            notFound: true,
+        }
+    }
+
     return {
         props: {
-            user: data.getUser || null
+            user: data.getUser
         }
     }
 }

--- a/src/components/User/CharacterGroupList.tsx
+++ b/src/components/User/CharacterGroupList.tsx
@@ -6,14 +6,15 @@ import type { CharacterGroup } from "./types";
 interface ComponentProps {
     currentGroupId: string | null;
     groups: readonly CharacterGroup[];
+    numCharacters: number;
     username: string;
 }
 
-function CharacterGroupList({ currentGroupId, groups, username }: ComponentProps): React.ReactElement {
+function CharacterGroupList({ currentGroupId, groups, numCharacters, username }: ComponentProps): React.ReactElement {
     return (
         <ul className="character-group-list margin-bottom--none">
             <CharacterGroupListItem
-                count={999999}
+                count={numCharacters}
                 icon="person"
                 id={null}
                 isActive={!currentGroupId}

--- a/src/components/User/CharacterGroupList.tsx
+++ b/src/components/User/CharacterGroupList.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import CharacterGroupListItem from "./CharacterGroupListItem";
+import type { CharacterGroup } from "./types";
+
+
+interface ComponentProps {
+    currentGroupId: string | null;
+    groups: readonly CharacterGroup[];
+    username: string;
+}
+
+function CharacterGroupList({ currentGroupId, groups, username }: ComponentProps): React.ReactElement {
+    return (
+        <ul className="character-group-list margin-bottom--none">
+            <CharacterGroupListItem
+                count={999999}
+                icon="person"
+                id={null}
+                isActive={!currentGroupId}
+                isDraggable={false}
+                label="All Characters"
+                username={username}
+            />
+
+            {groups.map((group): React.ReactElement => {
+                return (
+                    <CharacterGroupListItem
+                        key={group.id}
+                        count={group.characterCount}
+                        icon="folder"
+                        id={group.id}
+                        isActive={currentGroupId === group.id}
+                        isDraggable={true}
+                        label={group.name}
+                        username={username}
+                    />
+                )
+            })}
+        </ul>
+    )
+}
+
+export default CharacterGroupList;

--- a/src/components/User/CharacterGroupListItem.tsx
+++ b/src/components/User/CharacterGroupListItem.tsx
@@ -1,0 +1,45 @@
+import classnames from "classnames";
+import Link from "next/link";
+import React from "react";
+import NumberUtils from "@refsheet/v1/utils/NumberUtils";
+
+type SupportedIcon = "person" | "folder";
+
+const ICON_DEFINITIONS: Record<SupportedIcon, { inactive: string; active: string }> = {
+    folder: {
+        active: "folder_open",
+        inactive: "folder",
+    },
+    person: {
+        active: "person",
+        inactive: "person",
+    },
+}
+
+interface ComponentProps {
+    count: number;
+    icon: SupportedIcon;
+    id: string | null;
+    isActive: boolean;
+    isDraggable: boolean;
+    label: string;
+    username: string;
+}
+
+function CharacterGroupListItem({ count, icon, id, isActive, isDraggable, label, username }: ComponentProps): React.ReactElement {
+    return (
+        <li className={classnames("character-group-list-item", isDraggable ? "sortable-link" : "fixed", isActive && "active")}>
+            <i className="material-icons left folder">
+                {isActive ? ICON_DEFINITIONS[icon].active : ICON_DEFINITIONS[icon].inactive}
+            </i>
+            <Link href={id ? `/${username}#${id}` : `/${username}`} passHref>
+                <a className="name">{label}</a>
+            </Link>
+            <span className="count">
+                {NumberUtils.format(count)}
+            </span>
+        </li>
+    );
+}
+
+export default CharacterGroupListItem;

--- a/src/components/User/View.tsx
+++ b/src/components/User/View.tsx
@@ -1,18 +1,22 @@
+import { useRouter } from "next/router";
 import Section from "../Shared/Section";
 import Main from "../Shared/Main";
 import React from "react";
 import {extractRoles, IUserRoles} from "../../utils/UserUtils";
 import UserProfileHeader from "./UserProfileHeader";
 import {GetUserProfileQuery} from "../../../@types/schema";
-import Link from "next/link";
-import NumberUtils from "../../v1/utils/NumberUtils";
+import CharacterGroupList from "./CharacterGroupList";
+import type { CharacterGroup } from "./types";
+import useCurrentCharacterGroup from "./useCurrentCharacterGroup";
 
 export interface IUserViewProps {
+    characterGroups: readonly CharacterGroup[];
     user: NonNullable<GetUserProfileQuery['getUser']>
 }
 
-const UserView: React.FC<IUserViewProps> = ({user}) => {
+const UserView: React.FC<IUserViewProps> = ({ characterGroups, user }) => {
     const roles: IUserRoles = extractRoles(user);
+    const currentCharacterGroupId = useCurrentCharacterGroup();
 
     return (
         <Main title={[user.name, 'Users']}>
@@ -29,27 +33,15 @@ const UserView: React.FC<IUserViewProps> = ({user}) => {
             <Section container className="margin-top--large padding-bottom--none">
                 <div className="sidebar-container">
                     <div className="sidebar">
-                        <ul className="character-group-list margin-bottom--none">
-                            <li className="all fixed">
-                                <i className="material-icons left folder">person</i>
-                                <Link href={`/${user.username}`} className="name">All Characters</Link>
-                                <span className="count">
-                                    {NumberUtils.format(999999)}
-                                </span>
-                            </li>
-
-                            {user.character_groups?.map((group) => group && (
-                                <li className="something">
-                                    <i className="material-icons left folder">folder</i>
-                                    <Link href={`/${user.username}#${group.name}`}>{group.name}</Link>
-                                    <span className="count">{NumberUtils.format(group.characters_count)}</span>
-                                </li>
-                            ))}
-                        </ul>
+                        <CharacterGroupList
+                            currentGroupId={currentCharacterGroupId}
+                            groups={characterGroups}
+                            username={user.username || "deleted-" + user.id}
+                        />
                     </div>
 
                     <div className="main-content">
-                        ( characters )
+                        {currentCharacterGroupId ? `(characters from ${currentCharacterGroupId})` : "(all characters)"}
                     </div>
                 </div>
             </Section>

--- a/src/components/User/View.tsx
+++ b/src/components/User/View.tsx
@@ -11,10 +11,11 @@ import useCurrentCharacterGroup from "./useCurrentCharacterGroup";
 
 export interface IUserViewProps {
     characterGroups: readonly CharacterGroup[];
+    numCharacters: number;
     user: NonNullable<GetUserProfileQuery['getUser']>
 }
 
-const UserView: React.FC<IUserViewProps> = ({ characterGroups, user }) => {
+const UserView: React.FC<IUserViewProps> = ({ characterGroups, numCharacters, user }) => {
     const roles: IUserRoles = extractRoles(user);
     const currentCharacterGroupId = useCurrentCharacterGroup();
 
@@ -36,6 +37,7 @@ const UserView: React.FC<IUserViewProps> = ({ characterGroups, user }) => {
                         <CharacterGroupList
                             currentGroupId={currentCharacterGroupId}
                             groups={characterGroups}
+                            numCharacters={numCharacters}
                             username={user.username || "deleted-" + user.id}
                         />
                     </div>

--- a/src/components/User/types.ts
+++ b/src/components/User/types.ts
@@ -1,0 +1,5 @@
+export interface CharacterGroup {
+    id: string;
+    characterCount: number;
+    name: string;
+}

--- a/src/components/User/useCurrentCharacterGroup.ts
+++ b/src/components/User/useCurrentCharacterGroup.ts
@@ -1,0 +1,29 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+function getCharacterGroupId(url: string): string | null {
+    const index = url.indexOf("#");
+    if (index < 0) {
+        return null;
+    }
+
+    return url.substring(index + 1);
+}
+
+function useCurrentCharacterGroup(): string | null {
+    const router = useRouter();
+    const [currentCharacterGroupId, setCurrentCharacterGroupId] = useState<string | null>(getCharacterGroupId(router.asPath));
+
+    useEffect(() => {
+        const listener = (url: string): void => setCurrentCharacterGroupId(getCharacterGroupId(url));
+
+        router.events.on("hashChangeStart", listener);
+        return (): void => {
+            router.events.off("hashChangeStart", listener);
+        }
+    }, [router]);
+
+    return currentCharacterGroupId;
+}
+
+export default useCurrentCharacterGroup;

--- a/src/graph/queries/getUserProfile.graphql
+++ b/src/graph/queries/getUserProfile.graphql
@@ -18,6 +18,7 @@ query getUserProfile($username: String!) {
         is_patron
 
         character_groups {
+            id
             name
             characters_count
         }

--- a/src/graph/queries/getUserProfile.graphql
+++ b/src/graph/queries/getUserProfile.graphql
@@ -4,6 +4,7 @@ query getUserProfile($username: String!) {
         name
         username
         created_at
+        characters_count
         profile
         profile_html
         profile_image_url

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import type { ParsedUrlQuery } from "querystring";
+
+export type GsspParams<TPathParams> = GetServerSidePropsContext<TPathParams & ParsedUrlQuery>;
+export type GsspResult<TPageProps> = Promise<GetServerSidePropsResult<TPageProps>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,12 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": "./src",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@refsheet/*": [
+        "./*"
+      ],
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
On the user profile, the sidebar had a partial implementation of the character groups. This displayed some hardcoded data for **All Characters**, and didn't feature the color highlighting/text wrapping on the main site.

I've made an initial pass at implementing this. I focused for the moment on just the "readonly" behavior — that is, the functionality that you'd see when you're visiting someone else's profile. Mutable actions (such as actually implementing drag/drop, deleting groups, creating new groups, adding characters to an existing group) can come at a later time.

Notes:
* I found that, on the main site, you can actually visually drag/drop another user's groups. It doesn't appear to save, though it does seem to make a GQL call;
* I've changed the schema of what's being serialized to the URL hash (to indicate a user's group)
  * **Main site:** https://refsheet.net/ahlec#bar-1 (a combination of group name + optional character count, if populated)
  * **My implementation:** http://localhost:3000/ahlec#64740 (group ID)
  * I chose this because I felt like the group ID was a better, well, identifier. The URL is still kept short and readable, but we're able to eschew the "do I include the character count?" logic, and also it eliminates certain bugs like "what if you have TWO empty groups with the same name?"
    * This wouldn't be difficult to change if you'd prefer the original, though, so I'm open to changing it
* I introduced some additional types for the `getServerSideProps` function. These are just aliases to the Next functions, but I find that this keeps the function signatures cleaner while producing better error messages for TypeScript.
  * On this latter point, using the `const getServerSideProps: GetServerSideProps<...> = () => { ... }` signature produces unwieldy and annoying errors when one or more of the `return` statements inside doesn't 100% conform to spec. Most annoyingly, this signature won't actually tell you which location isn't in compliance. Changing to the signature I've introduced here will have TypeScript tell you the exact location.
* It appears that the **src/** directory is a "top-level" domain for TypeScript. I added the file at **src/types.ts** in the repository, but it feels weird to write `import { } from "types"`. To get around this, I added an import path alias so that anything in **src/** is _also_ addressable as `@refsheet/*`
  * I'm also flexible on what the import path is here, so if you'd prefer something like `~refsheet` or `myFoo` or w/e, I'm down to change it

Oh, finally: I moved the 404 for the user profile to the server, rather than checking it on the client. Doing it inside of `getServerSideProps` allows us to automatically serve a 404 HTTP status code rather than a 200. It also skips rendering our component (so we can mark our component's prop as `NonNullable`) and will instead render the official 404 page.

#### Screenshots

**Before:**
<img width="216" alt="image" src="https://github.com/Refsheet/refsheet-site-frontend/assets/1350141/2681d7f7-7061-418e-9d8a-9c73a3610695">

**After:**
<img width="228" alt="image" src="https://github.com/Refsheet/refsheet-site-frontend/assets/1350141/02744754-8649-4598-ad89-0148a6144625">
